### PR TITLE
Add CAN periph RX interface

### DIFF
--- a/CAN-D/Inc/bridge.h
+++ b/CAN-D/Inc/bridge.h
@@ -1,0 +1,39 @@
+/**
+  ******************************************************************************
+  * File Name          : bridge.h
+  * Description        : This file provides code for bridging peripheral
+  *                      instances
+  ******************************************************************************
+  */
+
+#ifndef BRIDGE_H_
+#define BRIDGE_H_
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "main.h"
+#include "cmsis_os.h"
+
+/* Application configuration */
+typedef struct
+{
+  uint8_t SDStorage;
+  uint8_t USBTransfer;
+} APP_ConfigType;
+
+typedef enum
+{
+  APP_DISABLE = 0,
+  APP_ENABLE = 1
+} APP_ConfigurationState;
+
+extern APP_ConfigType mAppConfiguration;
+
+void APP_BRIDGE_ConfigTask(void const * argument);
+void APP_CAN_SetConfiguration(APP_ConfigType newConfig);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* BRIDGE_H_ */

--- a/CAN-D/Inc/can.h
+++ b/CAN-D/Inc/can.h
@@ -14,8 +14,15 @@
 #endif
 
 #include "main.h"
+#include "cmsis_os.h"
+
+#define CAN_RX_FIFO_0      ((uint32_t) 0)
+#define CAN_RX_FIFO_1      ((uint32_t) 1)
+#define CAN_RXQ_TIMEOUT_MS ((uint32_t) 250) /* Timeout when waiting on the can RX queue*/
+#define CAN_START_ITS      CAN_IT_RX_FIFO0_FULL | CAN_IT_RX_FIFO1_FULL | CAN_IT_ERROR  /* Interrupts to be enabled on CAN start */
 
 extern CAN_HandleTypeDef hcan;
+extern osMessageQId canDataQueueHandle;
 
 void MX_CAN_Init(void);
 

--- a/CAN-D/Inc/can.h
+++ b/CAN-D/Inc/can.h
@@ -19,7 +19,7 @@
 #define CAN_RX_FIFO_0      ((uint32_t) 0)
 #define CAN_RX_FIFO_1      ((uint32_t) 1)
 #define CAN_RXQ_TIMEOUT_MS ((uint32_t) 250) /* Timeout when waiting on the can RX queue*/
-#define CAN_START_ITS      CAN_IT_RX_FIFO0_FULL | CAN_IT_RX_FIFO1_FULL | CAN_IT_ERROR  /* Interrupts to be enabled on CAN start */
+#define CAN_IT_START       CAN_IT_RX_FIFO0_FULL | CAN_IT_RX_FIFO1_FULL | CAN_IT_ERROR  /* Interrupts to be enabled on CAN start */
 
 extern CAN_HandleTypeDef hcan;
 extern osMessageQId canDataQueueHandle;

--- a/CAN-D/Inc/can.h
+++ b/CAN-D/Inc/can.h
@@ -14,7 +14,6 @@
 #endif
 
 #include "main.h"
-#include "cmsis_os.h"
 
 #define CAN_RX_FIFO_0      ((uint32_t) 0)
 #define CAN_RX_FIFO_1      ((uint32_t) 1)
@@ -22,9 +21,9 @@
 #define CAN_IT_START       CAN_IT_RX_FIFO0_FULL | CAN_IT_RX_FIFO1_FULL | CAN_IT_ERROR  /* Interrupts to be enabled on CAN start */
 
 extern CAN_HandleTypeDef hcan;
-extern osMessageQId canDataQueueHandle;
 
 void MX_CAN_Init(void);
+void APP_CAN_StartStop(void);
 
 #ifdef __cplusplus
 }

--- a/CAN-D/Src/bridge.c
+++ b/CAN-D/Src/bridge.c
@@ -1,0 +1,48 @@
+/**
+  ******************************************************************************
+  * File Name          : bridge.c
+  * Description        : This file provides code for bridging peripheral
+  *                      instances
+  ******************************************************************************
+  */
+
+#include "bridge.h"
+#include "can.h"
+
+APP_ConfigType mAppConfiguration = {0};
+
+void APP_CAN_Init(void)
+{
+  mAppConfiguration.SDStorage = APP_DISABLE;
+  mAppConfiguration.USBTransfer = APP_DISABLE;
+}
+
+/**
+  * @brief  Function implementing the APP_BRIDGE_ConfigTask thread.
+  * @param  argument: Not used
+  * @retval None
+  */
+void APP_BRIDGE_ConfigTask(void const * argument)
+{
+  for(;;)
+  {
+    // TODO: create BSP pkg for our PCB
+    // Start/Stop the CAN module on button press
+//    if (BSP_PB_GetState(BUTTON_KEY) == KEY_PRESSED)
+//    {
+//      APP_CAN_StartStop();
+//    }
+
+    osDelay(1);
+  }
+}
+
+/**
+  * @brief  Sets the APP Configuration
+  * @param  newConfig: the configuration to set
+  * @retval None
+  */
+void APP_CAN_SetConfiguration(APP_ConfigType newConfig)
+{
+  mAppConfiguration = newConfig;
+}

--- a/CAN-D/Src/can.c
+++ b/CAN-D/Src/can.c
@@ -107,22 +107,18 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* canHandle)
   */
 void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef* canHandle)
 {
-  uint8_t rxData;
-  osStatus status;
-  HAL_StatusTypeDef err_code = HAL_OK;
+  uint8_t rxData[8];
   CAN_RxHeaderTypeDef pHeader = {0};
 
   // Get CAN RX data from the CAN module
-  err_code = HAL_CAN_GetRxMessage(canHandle, CAN_RX_FIFO_0, &pHeader, &rxData);
-  if (err_code != HAL_OK)
+  if (HAL_CAN_GetRxMessage(canHandle, CAN_RX_FIFO_0, &pHeader, rxData) != HAL_OK)
   {
     Error_Handler();
   }
 
   // Pass the CAN RX data to the CAN RX data queue
   // @see canBridgeTask()
-  status = osMessagePut(canDataQueueHandle, (uint32_t)rxData, CAN_RXQ_TIMEOUT_MS);
-  if (status != osOK)
+  if (osMessagePut(canDataQueueHandle, (uint32_t)rxData, CAN_RXQ_TIMEOUT_MS) != osOK)
   {
     Error_Handler();
   }

--- a/CAN-D/Src/can.c
+++ b/CAN-D/Src/can.c
@@ -10,10 +10,10 @@
 
 CAN_HandleTypeDef hcan;
 
+
 /* CAN init function */
 void MX_CAN_Init(void)
 {
-
   hcan.Instance = CAN;
   hcan.Init.Prescaler = 16;
   hcan.Init.Mode = CAN_MODE_NORMAL;
@@ -31,11 +31,11 @@ void MX_CAN_Init(void)
     Error_Handler();
   }
 
+  // TODO: configure CAN reception filters using HAL_CAN_ConfigFilter()
 }
 
 void HAL_CAN_MspInit(CAN_HandleTypeDef* canHandle)
 {
-
   GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(canHandle->Instance==CAN)
   {
@@ -55,18 +55,18 @@ void HAL_CAN_MspInit(CAN_HandleTypeDef* canHandle)
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
     /* CAN interrupt Init */
-    HAL_NVIC_SetPriority(USB_HP_CAN_TX_IRQn, 5, 0);
-    HAL_NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
-    HAL_NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, 5, 0);
-    HAL_NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
-    HAL_NVIC_SetPriority(CAN_RX1_IRQn, 5, 0);
+    // Disabling unused interrupts for now
+//    HAL_NVIC_SetPriority(USB_HP_CAN_TX_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
+//    HAL_NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
+    HAL_NVIC_SetPriority(CAN_RX1_IRQn, 1, 0);
     HAL_NVIC_EnableIRQ(CAN_RX1_IRQn);
   }
 }
 
 void HAL_CAN_MspDeInit(CAN_HandleTypeDef* canHandle)
 {
-
   if(canHandle->Instance==CAN)
   {
     /* Peripheral clock disable */
@@ -79,22 +79,66 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* canHandle)
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_8|GPIO_PIN_9);
 
     /* CAN interrupt Deinit */
-  /* USER CODE BEGIN CAN:USB_HP_CAN_TX_IRQn disable */
+  /* BEGIN CAN:USB_HP_CAN_TX_IRQn disable */
     /**
     * Uncomment the line below to disable the "USB_HP_CAN_TX_IRQn" interrupt
     * Be aware, disabling shared interrupt may affect other IPs
     */
     /* HAL_NVIC_DisableIRQ(USB_HP_CAN_TX_IRQn); */
-  /* USER CODE END CAN:USB_HP_CAN_TX_IRQn disable */
+  /* END CAN:USB_HP_CAN_TX_IRQn disable */
 
-  /* USER CODE BEGIN CAN:USB_LP_CAN_RX0_IRQn disable */
+  /* BEGIN CAN:USB_LP_CAN_RX0_IRQn disable */
     /**
     * Uncomment the line below to disable the "USB_LP_CAN_RX0_IRQn" interrupt
     * Be aware, disabling shared interrupt may affect other IPs
     */
     /* HAL_NVIC_DisableIRQ(USB_LP_CAN_RX0_IRQn); */
-  /* USER CODE END CAN:USB_LP_CAN_RX0_IRQn disable */
+  /* END CAN:USB_LP_CAN_RX0_IRQn disable */
 
     HAL_NVIC_DisableIRQ(CAN_RX1_IRQn);
   }
 }
+
+/**
+  * @brief  Rx FIFO 0 full callback.
+  * @param  CanHandle: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef* canHandle)
+{
+  uint8_t rxData;
+  osStatus status;
+  HAL_StatusTypeDef err_code = HAL_OK;
+  CAN_RxHeaderTypeDef pHeader = {0};
+
+  // Get CAN RX data from the CAN module
+  err_code = HAL_CAN_GetRxMessage(canHandle, CAN_RX_FIFO_0, &pHeader, &rxData);
+  if (err_code != HAL_OK)
+  {
+    Error_Handler();
+  }
+
+  // Pass the CAN RX data to the CAN RX data queue
+  // @see canBridgeTask()
+  status = osMessagePut(canDataQueueHandle, (uint32_t)rxData, CAN_RXQ_TIMEOUT_MS);
+  if (status != osOK)
+  {
+    Error_Handler();
+  }
+}
+
+/**
+  * @brief  Rx FIFO 1 full callback.
+  * @param  CanHandle: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef* canHandle)
+{
+  // TODO: Figure out how these fifos work. We currently enabled both FIFO
+  //       interrupts (0 and 1) but I'm not sure how to properly handle data
+  //       coming from both FIFOs at onee. Maybe just do the same as in
+  //       HAL_CAN_RxFifo0MsgPendingCallback() ?
+}
+

--- a/CAN-D/Src/freertos.c
+++ b/CAN-D/Src/freertos.c
@@ -9,12 +9,10 @@
 #include "task.h"
 #include "main.h"
 #include "cmsis_os.h"
-#include "can.h"
+#include "bridge.h"
 
-osThreadId canTaskHandle;
-osMessageQId canDataQueueHandle;
+osThreadId bridgeConfigTaskHandle;
 
-void canBridgeTask(void const * argument);
 void MX_FREERTOS_Init(void); /* (MISRA C 2004 rule 8.1) */
 
 
@@ -32,57 +30,10 @@ void MX_FREERTOS_Init(void)
   /* start timers, add new ones, ... */
 
   /* Create the thread(s) */
-  osThreadDef(canTask, canBridgeTask, osPriorityNormal, 0, 128);
-  canTaskHandle = osThreadCreate(osThread(canTask), NULL);
+  osThreadDef(bridgeConfigTask, APP_BRIDGE_ConfigTask, osPriorityNormal, 0, 128);
+  bridgeConfigTaskHandle = osThreadCreate(osThread(bridgeConfigTask), NULL);
 
   /* add threads, ... */
 
   /* add queues, ... */
-  osMessageQDef(canDataQueue, 8, uint8_t);
-  canDataQueueHandle = osMessageCreate(osMessageQ(canDataQueue), NULL);
-}
-
-/**
-  * @brief  Function implementing the canBridgeTask thread.
-  * @param  argument: Not used 
-  * @retval None
-  */
-void canBridgeTask(void const * argument)
-{
-  for(;;)
-  {
-    // TODO: create BSP pkg for our PCB
-
-    // Start/Stop the CAN module on button press
-//    if (BSP_PB_GetState(BUTTON_KEY) == KEY_PRESSED)
-//    {
-//      if (hcan.State == HAL_CAN_STATE_LISTENING)
-//      {
-//        HAL_CAN_Stop(&hcan);
-//        HAL_CAN_DeactivateNotification(&hcan, CAN_IT_START);
-//      }
-//      else if (hcan.State == HAL_CAN_STATE_READY)
-//      {
-//        // Changes the hcan.State to HAL_CAN_STATE_LISTENING
-//        HAL_CAN_Start(&hcan);
-//        HAL_CAN_ActivateNotification(&hcan, CAN_IT_START);
-//      }
-//    }
-
-    // Monitor CAN RX data
-    if (hcan.State == HAL_CAN_STATE_LISTENING)
-    {
-      osEvent event;
-      uint8_t rxData;
-
-      event = osMessageGet(canDataQueueHandle, CAN_RXQ_TIMEOUT_MS);
-      if (event.status == osEventMessage)
-      {
-        rxData = (uint8_t)event.value.v;
-        // TODO: pass along CAN RX data
-      }
-    }
-
-	  osDelay(1);
-  }
 }

--- a/CAN-D/Src/freertos.c
+++ b/CAN-D/Src/freertos.c
@@ -9,20 +9,24 @@
 #include "task.h"
 #include "main.h"
 #include "cmsis_os.h"
+#include "can.h"
 
-osThreadId defaultTaskHandle;
+CAN_HandleTypeDef hcan; /* Shared extern from can.h */
 
-void StartDefaultTask(void const * argument);
+osThreadId canTaskHandle;
+osMessageQId canDataQueueHandle;
 
-extern void MX_USB_DEVICE_Init(void);
+void canBridgeTask(void const * argument);
 void MX_FREERTOS_Init(void); /* (MISRA C 2004 rule 8.1) */
+
 
 /**
   * @brief  FreeRTOS initialization
   * @param  None
   * @retval None
   */
-void MX_FREERTOS_Init(void) {
+void MX_FREERTOS_Init(void)
+{
   /* add mutexes, ... */
 
   /* add semaphores, ... */
@@ -31,25 +35,57 @@ void MX_FREERTOS_Init(void) {
 
   /* Create the thread(s) */
   /* definition and creation of defaultTask */
-  osThreadDef(defaultTask, StartDefaultTask, osPriorityNormal, 0, 128);
-  defaultTaskHandle = osThreadCreate(osThread(defaultTask), NULL);
+  osThreadDef(canTask, canBridgeTask, osPriorityNormal, 0, 128);
+  canTaskHandle = osThreadCreate(osThread(canTask), NULL);
 
   /* add threads, ... */
 
   /* add queues, ... */
-
+  osMessageQDef(canDataQueue, 8, uint8_t);
+  canDataQueueHandle = osMessageCreate(osMessageQ(canDataQueue), NULL);
 }
 
 /**
-  * @brief  Function implementing the defaultTask thread.
+  * @brief  Function implementing the canBridgeTask thread.
   * @param  argument: Not used 
   * @retval None
   */
-/* USER CODE END Header_StartDefaultTask */
-void StartDefaultTask(void const * argument)
+void canBridgeTask(void const * argument)
 {
   for(;;)
   {
-    osDelay(1);
+    // TODO: create BSP pkg for our PCB
+
+    // Start/Stop the CAN module on button press
+//    if (BSP_PB_GetState(BUTTON_KEY) == KEY_PRESSED)
+//    {
+//      if (hcan.State == HAL_CAN_STATE_LISTENING)
+//      {
+//        HAL_CAN_Stop(&hcan);
+//        HAL_CAN_DeactivateNotification(&hcan, CAN_START_ITS);
+//      }
+//      else if (hcan.State == HAL_CAN_STATE_READY)
+//      {
+//        // Changes the hcan.State to HAL_CAN_STATE_LISTENING
+//        HAL_CAN_Start(&hcan);
+//        HAL_CAN_ActivateNotification(&hcan, CAN_START_ITS);
+//      }
+//    }
+
+    // Monitor CAN RX data
+    if (hcan.State == HAL_CAN_STATE_LISTENING)
+    {
+      osEvent event;
+      uint8_t rxData;
+
+      event = osMessageGet(canDataQueueHandle, CAN_RXQ_TIMEOUT_MS);
+      if (event.status == osEventMessage)
+      {
+        rxData = (uint8_t)event.value.v;
+        // TODO: pass along CAN RX data
+      }
+    }
+
+	  osDelay(1);
   }
 }

--- a/CAN-D/Src/freertos.c
+++ b/CAN-D/Src/freertos.c
@@ -11,8 +11,6 @@
 #include "cmsis_os.h"
 #include "can.h"
 
-CAN_HandleTypeDef hcan; /* Shared extern from can.h */
-
 osThreadId canTaskHandle;
 osMessageQId canDataQueueHandle;
 
@@ -34,7 +32,6 @@ void MX_FREERTOS_Init(void)
   /* start timers, add new ones, ... */
 
   /* Create the thread(s) */
-  /* definition and creation of defaultTask */
   osThreadDef(canTask, canBridgeTask, osPriorityNormal, 0, 128);
   canTaskHandle = osThreadCreate(osThread(canTask), NULL);
 
@@ -62,13 +59,13 @@ void canBridgeTask(void const * argument)
 //      if (hcan.State == HAL_CAN_STATE_LISTENING)
 //      {
 //        HAL_CAN_Stop(&hcan);
-//        HAL_CAN_DeactivateNotification(&hcan, CAN_START_ITS);
+//        HAL_CAN_DeactivateNotification(&hcan, CAN_IT_START);
 //      }
 //      else if (hcan.State == HAL_CAN_STATE_READY)
 //      {
 //        // Changes the hcan.State to HAL_CAN_STATE_LISTENING
 //        HAL_CAN_Start(&hcan);
-//        HAL_CAN_ActivateNotification(&hcan, CAN_START_ITS);
+//        HAL_CAN_ActivateNotification(&hcan, CAN_IT_START);
 //      }
 //    }
 

--- a/CAN-D/Src/main.c
+++ b/CAN-D/Src/main.c
@@ -16,7 +16,7 @@
 #include "gpio.h"
 #include "stm32f3xx_hal_pwr.h"
 
-extern void MX_USB_DEVICE_Init(void);
+void MX_USB_DEVICE_Init(void);
 void SystemClock_Config(void);
 void MX_FREERTOS_Init(void);
 

--- a/CAN-D/Src/main.c
+++ b/CAN-D/Src/main.c
@@ -1,54 +1,10 @@
-/* USER CODE BEGIN Header */
 /**
   ******************************************************************************
   * @file           : main.c
   * @brief          : Main program body
   ******************************************************************************
-  * This notice applies to any and all portions of this file
-  * that are not between comment pairs USER CODE BEGIN and
-  * USER CODE END. Other portions of this file, whether 
-  * inserted by the user or by software development tools
-  * are owned by their respective copyright owners.
-  *
-  * Copyright (c) 2019 STMicroelectronics International N.V. 
-  * All rights reserved.
-  *
-  * Redistribution and use in source and binary forms, with or without 
-  * modification, are permitted, provided that the following conditions are met:
-  *
-  * 1. Redistribution of source code must retain the above copyright notice, 
-  *    this list of conditions and the following disclaimer.
-  * 2. Redistributions in binary form must reproduce the above copyright notice,
-  *    this list of conditions and the following disclaimer in the documentation
-  *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other 
-  *    contributors to this software may be used to endorse or promote products 
-  *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this 
-  *    software, must execute solely and exclusively on microcontroller or
-  *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under 
-  *    this license is void and will automatically terminate your rights under 
-  *    this license. 
-  *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" 
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT 
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
-  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT 
-  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
-/* USER CODE END Header */
+*/
 
-/* Includes ------------------------------------------------------------------*/
 #include "main.h"
 #include "cmsis_os.h"
 #include "can.h"
@@ -60,43 +16,10 @@
 #include "gpio.h"
 #include "stm32f3xx_hal_pwr.h"
 
-/* Private includes ----------------------------------------------------------*/
-/* USER CODE BEGIN Includes */
-
-/* USER CODE END Includes */
-
-/* Private typedef -----------------------------------------------------------*/
-/* USER CODE BEGIN PTD */
-
-/* USER CODE END PTD */
-
-/* Private define ------------------------------------------------------------*/
-/* USER CODE BEGIN PD */
-
-/* USER CODE END PD */
-
-/* Private macro -------------------------------------------------------------*/
-/* USER CODE BEGIN PM */
-
-/* USER CODE END PM */
-
-/* Private variables ---------------------------------------------------------*/
-
-/* USER CODE BEGIN PV */
-
-/* USER CODE END PV */
-
-/* Private function prototypes -----------------------------------------------*/
+extern void MX_USB_DEVICE_Init(void);
 void SystemClock_Config(void);
 void MX_FREERTOS_Init(void);
-/* USER CODE BEGIN PFP */
 
-/* USER CODE END PFP */
-
-/* Private user code ---------------------------------------------------------*/
-/* USER CODE BEGIN 0 */
-
-/* USER CODE END 0 */
 
 /**
   * @brief  The application entry point.
@@ -104,38 +27,21 @@ void MX_FREERTOS_Init(void);
   */
 int main(void)
 {
-  /* USER CODE BEGIN 1 */
-
-  /* USER CODE END 1 */
-
-  /* MCU Configuration--------------------------------------------------------*/
-
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
 
-  /* USER CODE BEGIN Init */
-
-  /* USER CODE END Init */
-
   /* Configure the system clock */
   SystemClock_Config();
-
-  /* USER CODE BEGIN SysInit */
-
-  /* USER CODE END SysInit */
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
   MX_CAN_Init();
   MX_SPI1_Init();
   MX_SPI2_Init();
-//  MX_TIM2_Init();
+  MX_TIM2_Init();
   MX_RTC_Init();
   MX_USART2_UART_Init();
   MX_USB_DEVICE_Init();
-  /* USER CODE BEGIN 2 */
-
-  /* USER CODE END 2 */
 
   /* Call init function for freertos objects (in freertos.c) */
   MX_FREERTOS_Init();
@@ -195,10 +101,6 @@ void SystemClock_Config(void)
   }
 }
 
-/* USER CODE BEGIN 4 */
-
-/* USER CODE END 4 */
-
 /**
   * @brief  Period elapsed callback in non blocking mode
   * @note   This function is called  when TIM1 interrupt took place, inside
@@ -209,15 +111,9 @@ void SystemClock_Config(void)
   */
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-  /* USER CODE BEGIN Callback 0 */
-
-  /* USER CODE END Callback 0 */
   if (htim->Instance == TIM1) {
     HAL_IncTick();
   }
-  /* USER CODE BEGIN Callback 1 */
-
-  /* USER CODE END Callback 1 */
 }
 
 /**
@@ -226,10 +122,6 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   */
 void Error_Handler(void)
 {
-  /* USER CODE BEGIN Error_Handler_Debug */
-  /* User can add his own implementation to report the HAL error return state */
-
-  /* USER CODE END Error_Handler_Debug */
 }
 
 #ifdef  USE_FULL_ASSERT
@@ -242,11 +134,7 @@ void Error_Handler(void)
   */
 void assert_failed(char *file, uint32_t line)
 { 
-  /* USER CODE BEGIN 6 */
   /* User can add his own implementation to report the file name and line number,
      tex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-  /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
- Adds two callbacks in can.c to handle
  CAN RX data. Each callback handles a
  unique CAN FIFO. Only the callback for
  FIFO0 is implemented for now because
  I am still unsure how these FIFOs
  work.
- Adds the canBridgeTask to freertos.c.
  This task will monitor the CAN RX
  data and pass it along within the
  app layer accordingly.
- Adds some TODOs related to the CAN
  module.
- Removes comment bloat in main.c.
- NOTE: this is not tested and is just
        to define a structure/codeflow
        for future implementations of
        peripherals.