### PR TITLE
Add USB Stream logic to application

### DIFF
--- a/CAN-D/Inc/bridge.h
+++ b/CAN-D/Inc/bridge.h
@@ -15,12 +15,6 @@
 #include "main.h"
 #include "cmsis_os.h"
 
-/* Application configuration */
-typedef struct
-{
-  uint8_t SDStorage;
-  uint8_t USBTransfer;
-} APP_ConfigType;
 
 typedef enum
 {
@@ -28,9 +22,25 @@ typedef enum
   APP_ENABLE = 1
 } APP_ConfigurationState;
 
-extern APP_ConfigType mAppConfiguration;
+/* Application configuration */
+typedef struct
+{
+  APP_ConfigurationState SDStorage;    /* Store CAN Data on SD Card */
+  APP_ConfigurationState USBStream;    /* Transfer all SD Card data to PC via USB */
+  APP_ConfigurationState USBTransfer;  /* Transfer CAN Data directly to USB Device */
+} APP_ConfigType;
 
-void APP_BRIDGE_ConfigTask(void const * argument);
+APP_ConfigType mAppConfiguration;
+
+/* Threads */
+osThreadId bridgeConfigTaskHandle;
+osThreadId USBStreamTaskHandle;
+
+/* Queues */
+osMessageQId USBStreamQueueHandle;
+
+void APP_BRIDGE_CANConfigTask(void const * argument);
+void APP_BRIDGE_USBStreamTask(void const * argument);
 void APP_CAN_SetConfiguration(APP_ConfigType newConfig);
 
 #ifdef __cplusplus

--- a/CAN-D/Src/bridge.c
+++ b/CAN-D/Src/bridge.c
@@ -8,30 +8,59 @@
 
 #include "bridge.h"
 #include "can.h"
+#include "usbd_cdc_if.h"
+#include "stm32303c_custom.h"
+#include "stm32f3xx_hal_gpio.h"
 
 APP_ConfigType mAppConfiguration = {0};
 
 void APP_CAN_Init(void)
 {
   mAppConfiguration.SDStorage = APP_DISABLE;
+  mAppConfiguration.USBStream = APP_DISABLE;
   mAppConfiguration.USBTransfer = APP_DISABLE;
 }
 
 /**
-  * @brief  Function implementing the APP_BRIDGE_ConfigTask thread.
+  * @brief  Function implementing the APP_BRIDGE_CANConfigTask thread.
   * @param  argument: Not used
   * @retval None
   */
-void APP_BRIDGE_ConfigTask(void const * argument)
+void APP_BRIDGE_CANConfigTask(void const * argument)
 {
   for(;;)
   {
-    // TODO: create BSP pkg for our PCB
     // Start/Stop the CAN module on button press
-//    if (BSP_PB_GetState(BUTTON_KEY) == KEY_PRESSED)
-//    {
-//      APP_CAN_StartStop();
-//    }
+   if (BSP_PB_GetState(KEY_BUTTON_PIN) == GPIO_PIN_SET)
+   {
+     APP_CAN_StartStop();
+   }
+
+    osDelay(1);
+  }
+}
+
+/**
+  * @brief  Function implementing the APP_BRIDGE_USBStreamTask thread.
+  * @param  argument: Not used
+  * @retval None
+  */
+void APP_BRIDGE_USBStreamTask(void const * argument)
+{
+  osEvent event;
+
+  for(;;)
+  {
+    // Pend on any CAN data we want to stream to the PC
+    event = osMessageGet(USBStreamQueueHandle, 0);
+    if (event.status == osEventMessage)
+    {
+      // Fill the USB TX buffer with the CAN data
+      while (CDC_Transmit_FS((uint8_t*)event.value.p, (uint16_t)8) == 1)
+      {
+        // USB TX State is BUSY. Wait for it to be free.
+      }
+    }
 
     osDelay(1);
   }

--- a/CAN-D/Src/freertos.c
+++ b/CAN-D/Src/freertos.c
@@ -11,7 +11,9 @@
 #include "cmsis_os.h"
 #include "bridge.h"
 
-osThreadId bridgeConfigTaskHandle;
+extern osThreadId bridgeConfigTaskHandle;
+extern osThreadId USBStreamTaskHandle;
+extern osMessageQId USBStreamQueueHandle;
 
 void MX_FREERTOS_Init(void); /* (MISRA C 2004 rule 8.1) */
 
@@ -30,10 +32,15 @@ void MX_FREERTOS_Init(void)
   /* start timers, add new ones, ... */
 
   /* Create the thread(s) */
-  osThreadDef(bridgeConfigTask, APP_BRIDGE_ConfigTask, osPriorityNormal, 0, 128);
+  osThreadDef(bridgeConfigTask, APP_BRIDGE_CANConfigTask, osPriorityNormal, 0, 128);
   bridgeConfigTaskHandle = osThreadCreate(osThread(bridgeConfigTask), NULL);
+
+  osThreadDef(USBStreamTask, APP_BRIDGE_USBStreamTask, osPriorityNormal, 0, 128);
+  USBStreamTaskHandle = osThreadCreate(osThread(USBStreamTask), NULL);
 
   /* add threads, ... */
 
   /* add queues, ... */
+  osMessageQDef(USBStreamQueue, 8, uint8_t);
+  USBStreamQueueHandle = osMessageCreate(osMessageQ(USBStreamQueue), NULL);
 }


### PR DESCRIPTION
- Adds a new RTOS thread for capturing USB stream data.

- Adds logic in can.c to put CAN data in an event queue
  for the USB stream thread.

- Adds actual checking of the button state in the CAN
  config thread.