### PR TITLE
Fix Compile Warnings

### DIFF
--- a/CAN-D/Drivers/BSP/Src/stm32302c_custom.c
+++ b/CAN-D/Drivers/BSP/Src/stm32302c_custom.c
@@ -54,7 +54,6 @@ UART_HandleTypeDef huart;
 static void UARTx_Init(void);
 static void UARTx_MspInit(UART_HandleTypeDef *huart);
 static void UARTx_WriteChar(char Character);
-static void UARTx_Error(void);
 
 /* Link functions for GPS peripheral over UART */
 void GPS_IO_Init(void);
@@ -309,19 +308,6 @@ static void UARTx_WriteChar(char Character)
   // Prime the UART TX Data Register with the
   // character to send
   huart.Instance->TDR = Character;
-}
-
-/**
-  * @brief UART error treatment function
-  * @retval None
-  */
-static void UARTx_Error(void)
-{
-  /* De-initialize the UART communication */
-  HAL_UART_DeInit(&huart);
-
-  /* Re- Initiaize the UART communication */
-  UARTx_Init();
 }
 
 /******************************** LINK GPS Module ********************************/

--- a/CAN-D/Src/bridge.c
+++ b/CAN-D/Src/bridge.c
@@ -31,7 +31,7 @@ void APP_BRIDGE_CANConfigTask(void const * argument)
   for(;;)
   {
     // Start/Stop the CAN module on button press
-   if (BSP_PB_GetState(LOG_BUTTON_PIN) == GPIO_PIN_SET)
+   if (BSP_PB_GetState(BUTTON_LOG) == GPIO_PIN_SET)
    {
      APP_CAN_StartStop();
    }


### PR DESCRIPTION
- BSP_PB_GetState(LOG_BUTTON_PIN) was being
  used instead of BSP_PB_GetState(BUTTON_LOG).

- Removed UARTx_Error() since it wasn't being used.