### PR TITLE
Change GPS setting to RMC only

### DIFF
--- a/CAN-D/Drivers/BSP/Src/stm32302c_custom_gps.c
+++ b/CAN-D/Drivers/BSP/Src/stm32302c_custom_gps.c
@@ -30,6 +30,6 @@ void BSP_GPS_Init(void)
   // Configure GPS to use 1s update time
   GPS_IO_WriteString(PMTK_SET_NMEA_UPDATE_1HZ);
 
-  // Configure GPS to only output GPRMC and GGA data messages
-  GPS_IO_WriteString(PMTK_SET_NMEA_OUTPUT_RMCGGA);
+  // Configure GPS to only output GPRMC data messages
+  GPS_IO_WriteString(PMTK_SET_NMEA_OUTPUT_RMCONLY);
 }

--- a/CAN-D/Inc/bridge.h
+++ b/CAN-D/Inc/bridge.h
@@ -38,7 +38,6 @@ osThreadId GPSMonitorTaskHandle;
 /* Queues */
 osMessageQId USBStreamQueueHandle;
 osMessageQId UARTGprmcQueueHandle; /* Handles GPS GPRMC data */
-osMessageQId UARTGgaQueueHandle; /* Handles GPS GGA data */
 
 /* RTOS Tasks */
 void APP_BRIDGE_CANConfigTask(void const* argument);

--- a/CAN-D/Src/bridge.c
+++ b/CAN-D/Src/bridge.c
@@ -99,12 +99,6 @@ void APP_BRIDGE_GPSMonitorTask(void const *argument)
       {
         // Write data to SD card
       }
-
-      event = osMessageGet(UARTGgaQueueHandle, 0);
-      if (event.status == osEventMessage)
-      {
-        // Write data to SD card
-      }
     }
 
     osDelay(1);

--- a/CAN-D/Src/freertos.c
+++ b/CAN-D/Src/freertos.c
@@ -27,7 +27,6 @@ extern osThreadId GPSMonitorTaskHandle;
 
 extern osMessageQId USBStreamQueueHandle;
 extern osMessageQId UARTGprmcQueueHandle;
-extern osMessageQId UARTGgaQueueHandle;
 
 /* Private function prototypes -----------------------------------------------*/
 void MX_FREERTOS_Init(void); /* (MISRA C 2004 rule 8.1) */
@@ -64,9 +63,6 @@ void MX_FREERTOS_Init(void)
 
   osMessageQDef(UARTGprmcQueue, 128, char);
   UARTGprmcQueueHandle = osMessageCreate(osMessageQ(UARTGprmcQueue), NULL);
-
-  osMessageQDef(UARTGgaQueue, 128, char);
-  UARTGgaQueueHandle = osMessageCreate(osMessageQ(UARTGgaQueue), NULL);
 }
 
 /* Private functions ---------------------------------------------------------*/

--- a/CAN-D/Src/stm32f3xx_it.c
+++ b/CAN-D/Src/stm32f3xx_it.c
@@ -30,7 +30,6 @@ extern TIM_HandleTypeDef htim1;
 
 /* UART message Queues */
 extern osMessageQId UARTGprmcQueueHandle;
-extern osMessageQId UARTGgaQueueHandle;
 
 /* Private function prototypes -----------------------------------------------*/
 
@@ -160,11 +159,6 @@ void USART2_IRQHandler(void)
     // The GPS RX data will be held between '$' and '\n' characters
     if (rxData[rx_idx] == '$')
     {
-      // Put the received data in the respective queue
-      if (strncmp("$GPGGA", rxData, sizeof("$GPGGA") - 1) == 0)
-      {
-        osMessagePut(UARTGgaQueueHandle, (uint32_t)rxData[0], 0);
-      }
       if (strncmp("$GPRMC", rxData, sizeof("$GPRMC") - 1) == 0)
       {
         osMessagePut(UARTGprmcQueueHandle, (uint32_t)rxData[0], 0);


### PR DESCRIPTION
- GPS is now initialized to only send
  RMC (Recommended Minimum Navigation
  Information) messages, instead of
  RMC and GGA messages.

- Removes all applicaiton logic associated
  with the GPS GGA data.