### PR TITLE
Add SD Card Detection

### DIFF
--- a/CAN-D/Inc/fatfs.h
+++ b/CAN-D/Inc/fatfs.h
@@ -25,6 +25,7 @@ extern FATFS SDFatFS; /* File system object for SD logical drive */
 extern FIL SDFile; /* File object for SD card */
 
 void APP_FATFS_Init(void);
+void APP_FATFS_Deinit(void);
 uint8_t APP_FATFS_WriteSD(const uint8_t* writeData, uint32_t bytes, const char* fileName);
 
 #ifdef __cplusplus

--- a/CAN-D/Src/can.c
+++ b/CAN-D/Src/can.c
@@ -76,7 +76,7 @@ void MX_CAN_Init(void)
 
 void APP_CAN_InitTasks(void)
 {
-    osThreadDef(CANMonitorTask, APP_CAN_MonitorTask, osPriorityNormal, 0, 128);
+    osThreadDef(CANMonitorTask, APP_CAN_MonitorTask, osPriorityNormal, 0, 256);
     CANMonitorTaskHandle = osThreadCreate(osThread(CANMonitorTask), NULL);
 
     osThreadDef(CANTransmitTask, APP_CAN_TransmitTask, osPriorityNormal, 0, 128);
@@ -232,14 +232,14 @@ void APP_CAN_MonitorTask(void const* argument)
 {
     osEvent event;
     CANRxMessage* msg;
-    uint8_t yesno = 0;
 
     for (;;) {
-        if (yesno == 0) {
-            const uint8_t data[] = "Y";
-            APP_FATFS_WriteSD(data, 1, "CAN_data.log");
-            yesno = 1;
-        }
+
+        /* This is just used to test the SD card functionality */
+        //  const uint8_t data[] = "YELLOW";
+        //  volatile uint8_t temp = sizeof(data);
+        //  APP_FATFS_WriteSD(data, 6, "CAN_data.log");
+
         // Pend on any CAN Rx data
         event = osMessageGet(CANRxQueueHandle, 0);
         if (event.status == osEventMessage) {

--- a/CAN-D/Src/fatfs.c
+++ b/CAN-D/Src/fatfs.c
@@ -8,6 +8,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "fatfs.h"
 #include "cmsis_os.h"
+#include "stm32302c_custom_sd.h"
 
 /* Private typedef -----------------------------------------------------------*/
 
@@ -22,7 +23,7 @@ FRESULT resSD; /* Return value for SD */
 char SDPath[4]; /* SD logical drive path */
 FATFS SDFatFS; /* File system object for SD logical drive */
 FIL SDFile; /* File object for SD */
-
+static uint8_t SDInitialized = 0; /* Keeps track of if the SD card is initialized or not */
 /* Private function prototypes -----------------------------------------------*/
 
 /* Exported functions --------------------------------------------------------*/
@@ -30,6 +31,14 @@ void APP_FATFS_Init(void)
 {
     // Link the SD driver
     resSD = FATFS_LinkDriver(&SD_Driver, SDPath);
+    SDInitialized = 1;
+}
+
+void APP_FATFS_Deinit(void)
+{
+    f_mount(NULL, 0, 0); // Unmount
+    FATFS_UnLinkDriver(SDPath); // Unlink the SD Driver
+    SDInitialized = 0;
 }
 
 /**
@@ -43,17 +52,24 @@ uint8_t APP_FATFS_WriteSD(const uint8_t* writeData, uint32_t bytes, const char* 
 {
     uint32_t writtenBytes = 0;
 
-    // If already mounted, this should return FR_OK
-    if (f_mount(&SDFatFS, (TCHAR const*)SDPath, FATFS_FORCED_MOUNTING) == FR_OK) {
-        // Open the file for writing. Create new file if it doesn't exist
-        // osThreadResumeAll();
-        if ((f_open(&SDFile, fileName, FA_WRITE | FA_OPEN_ALWAYS)) == FR_OK) {
-            // Move the write pointer to the end of the file (append)
-            if (f_lseek(&SDFile, f_size(&SDFile)) == FR_OK) {
-                f_write(&SDFile, writeData, bytes, (void*)&writtenBytes);
-                f_close(&SDFile);
+    if (BSP_SD_IsDetected() == SD_PRESENT) {
+        // If the SD card was ejected but is now detected
+        if (SDInitialized == 0) {
+            APP_FATFS_Init();
+        }
+        if (f_mount(&SDFatFS, (TCHAR const*)SDPath, FATFS_FORCED_MOUNTING) == FR_OK) {
+            // Open the file for writing. Create new file if it doesn't exist
+            if ((f_open(&SDFile, fileName, FA_WRITE | FA_OPEN_ALWAYS)) == FR_OK) {
+                // Move the write pointer to the end of the file (append)
+                if (f_lseek(&SDFile, f_size(&SDFile)) == FR_OK) {
+                    f_write(&SDFile, writeData, bytes, (void*)&writtenBytes);
+                    f_close(&SDFile);
+                }
             }
         }
+        f_mount(NULL, 0, 0);
+    } else if (SDInitialized == 1) {
+        APP_FATFS_Deinit();
     }
 
     return writtenBytes;


### PR DESCRIPTION
- APP_FATFS_WriteSD() now checks if the SD card
  is initialized or not before attempting to
  write data.
  This allows for the user to eject or insert the
  SD card while the app is runnign without breaking
  anything.

- Changes the stack size of the CAN Monitor Task from
  128 to 256.
  I discovered that any task that uses FATFS functions
  need additional stack allocated to them or else the
  FATFS can't properly allocate space for mutexes/queues.