### PR TITLE
Add session counter to fatfs logging

### DIFF
--- a/CAN-D/Inc/fatfs.h
+++ b/CAN-D/Inc/fatfs.h
@@ -25,8 +25,10 @@ extern FATFS SDFatFS; /* File system object for SD logical drive */
 extern FIL SDFile; /* File object for SD card */
 
 void APP_FATFS_Init(void);
-char* APP_FATFS_GetUniqueFilename(char* filename);
 void APP_FATFS_Deinit(void);
+void APP_FATFS_StartSession(void);
+void APP_FATFS_StopSession(void);
+uint8_t APP_FATFS_LogSD(const uint8_t* writeData, uint32_t bytes, char* periphIdentifier);
 uint8_t APP_FATFS_WriteSD(const uint8_t* writeData, uint32_t bytes, const char* fileName);
 
 #ifdef __cplusplus

--- a/CAN-D/Src/gps.c
+++ b/CAN-D/Src/gps.c
@@ -22,8 +22,7 @@ typedef struct {
 #define GPS_BUFFER_LENGTH 2
 
 /* Private variables ---------------------------------------------------------*/
-static char gpsLogFilename[] = GPS_LOG_FILENAME;
-static char* gpsUniqueLogFilename = GPS_LOG_FILENAME;
+static char gpsLogIdentifier[] = GPS_LOG_FILENAME;
 /* Threads */
 static osThreadId GPSMonitorTaskHandle;
 /* Queues */
@@ -43,9 +42,6 @@ void APP_GPS_MonitorTask(void const* argument);
 void APP_GPS_Init(void)
 {
     BSP_GPS_Init();
-
-    // Create a unique log filename for each new new session
-    gpsUniqueLogFilename = APP_FATFS_GetUniqueFilename(gpsLogFilename);
 }
 
 void APP_GPS_InitTasks(void)
@@ -78,9 +74,6 @@ void APP_GPS_MonitorTask(void const* argument)
     GPSData* data;
 
     for (;;) {
-       const uint8_t adata[] = "YELLOW";
-       APP_FATFS_WriteSD(adata, 6, (const char*)gpsUniqueLogFilename);
-
         // Pend on GPS data sent via UART
         event = osMessageGet(UARTGprmcQueueHandle, 0);
         if (event.status == osEventMessage) {
@@ -89,7 +82,7 @@ void APP_GPS_MonitorTask(void const* argument)
             //if (mAppConfiguration.SDStorage == APP_ENABLE) {
             if (1) {
                 // Write data to SD card
-                APP_FATFS_WriteSD((const uint8_t*)data->raw, 128, gpsUniqueLogFilename);
+                APP_FATFS_LogSD((const uint8_t*)data->raw, 128, gpsLogIdentifier);
             }
             // TODO: BO: Moving around configurations, fix this
             //if (mAppConfiguration.USBStream == APP_ENABLE) {

--- a/CAN-D/Src/proto_handler.c
+++ b/CAN-D/Src/proto_handler.c
@@ -76,7 +76,10 @@ void interpretControlCommandMessage(ControlCommand* controlCommandMsg)
     case CONTROL_COMMAND_TYPE__MARK_LOG:
         // Add a UTC Timestampt to the Mark.log
         utc_str = APP_RTC_GetUTCTime();
-        APP_FATFS_WriteSD((const uint8_t*)utc_str, UTC_TIME_STR_LEN, "Mark.log");
+
+        // TODO: figure out if we are logging the marks in their own log file
+        //       or bundled in the CAN Data log.
+        APP_FATFS_LogSD((const uint8_t*)utc_str, UTC_TIME_STR_LEN, "CAN_Data");
         break;
     case CONTROL_COMMAND_TYPE__GET_LOGFS_INFO:
         /* code */

--- a/CAN-D/Src/stm32f3xx_it.c
+++ b/CAN-D/Src/stm32f3xx_it.c
@@ -142,26 +142,26 @@ void TIM2_IRQHandler(void)
   */
 void USART2_IRQHandler(void)
 {
-    char rxData[128] = "0";
-    uint8_t rx_idx = 0;
-    // Check if the UART2 Read Data Register has data
-    if (huart.Instance->ISR & USART_ISR_RXNE) {
-        // Read the data from the register
-        rxData[rx_idx] = huart.Instance->RDR;
-
-        // The GPS RX data will be held between '$' and '\n' characters
-        // TODO: BO: This is demo specific code
-        // if (rxData[rx_idx] == '$') {
-        if (1) {
-            // TODO: BO: This is demo specific code
-            // if (strncmp("$GPRMC", rxData, sizeof("$GPRMC") - 1) == 0)
-            //     APP_GPS_BufferGPSString(rxData, GPS_DATA_LENGTH);
-            APP_GPS_BufferGPSString(rxData, GPS_DATA_LENGTH);
-
-            memset(rxData, 0, sizeof(rxData));
-        }
-    }
-
+//    char rxData[128] = "0";
+//    uint8_t rx_idx = 0;
+//    // Check if the UART2 Read Data Register has data
+//    if (huart.Instance->ISR & USART_ISR_RXNE) {
+//        // Read the data from the register
+//        rxData[rx_idx] = huart.Instance->RDR;
+//
+//        // The GPS RX data will be held between '$' and '\n' characters
+//        // TODO: BO: This is demo specific code
+//        // if (rxData[rx_idx] == '$') {
+//        if (1) {
+//            // TODO: BO: This is demo specific code
+//            // if (strncmp("$GPRMC", rxData, sizeof("$GPRMC") - 1) == 0)
+//            //     APP_GPS_BufferGPSString(rxData, GPS_DATA_LENGTH);
+//            APP_GPS_BufferGPSString(rxData, GPS_DATA_LENGTH);
+//
+//            memset(rxData, 0, sizeof(rxData));
+//        }
+//    }
+//
     HAL_UART_IRQHandler(&huart);
 }
 


### PR DESCRIPTION
- FATFS logging now tracks the current session number
  in order to generate unique log identifiers.

- Peripherals now use APP_FATFS_LogSD() to log data.
  This was to prevent the need for can and gps to
  tracks their own unique log identifiers.

- When the CAN controller is started, it will now use
  APP_FATFS_StartSession() to generate a unique log
  identifier for all data sources. When stopped, CAN
  calls APP_FATFS_StopSession(), which prevents other
  data source (e.g. gps) from logging.