### PR TITLE
Flesh out USB Transfer App Logic

### DIFF
--- a/CAN-D/Inc/can.h
+++ b/CAN-D/Inc/can.h
@@ -21,6 +21,8 @@ extern "C" {
 #define CAN_IT_START CAN_IT_RX_FIFO0_FULL | CAN_IT_RX_FIFO1_FULL | CAN_IT_ERROR /* Interrupts to be enabled on CAN start */
 #define CAN_MESSAGE_LENGTH 8
 #define CAN_LOG_FILENAME "CAN_Data"
+#define CAN_USB_DATA_SZ_BYTES ((uint16_t)8)
+#define CAN_USB_TX_MAX_TRY 3
 
 typedef struct {
     CAN_HandleTypeDef* handle;
@@ -37,8 +39,7 @@ typedef struct {
 typedef struct
 {
     APP_ConfigurationState SDStorage; /* Store CAN Data on SD Card */
-    APP_ConfigurationState USBStream; /* Transfer all SD Card data to PC via USB */
-    APP_ConfigurationState USBTransfer; /* Transfer CAN Data directly to USB Device */
+    APP_ConfigurationState USBTransfer; /* Transfer all SD Card data to PC via USB */
     APP_ConfigurationState CANTransmit; /* Transmit data over the CAN bus */
 } APP_ConfigType;
 

--- a/CAN-D/Inc/gps.h
+++ b/CAN-D/Inc/gps.h
@@ -15,6 +15,8 @@ extern "C" {
 
 #define GPS_DATA_LENGTH 128
 #define GPS_LOG_FILENAME "GPS_Data"
+#define GPS_USB_DATA_SZ_BYTES ((uint16_t)128)
+#define GPS_USB_TX_MAX_TRY 3
 
 void APP_GPS_Init(void);
 void APP_GPS_InitTasks(void);

--- a/CAN-D/Inc/usbd_cdc_if.h
+++ b/CAN-D/Inc/usbd_cdc_if.h
@@ -18,6 +18,7 @@ extern "C" {
 /** CDC Interface callback. */
 extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
 
+uint8_t APP_USB_Transmit(uint8_t* data, uint16_t size);
 uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len);
 
 #ifdef __cplusplus

--- a/CAN-D/Src/usbd_cdc_if.c
+++ b/CAN-D/Src/usbd_cdc_if.c
@@ -45,6 +45,16 @@ USBD_CDC_ItfTypeDef USBD_Interface_fops_FS = {
 };
 
 /* Exported functions --------------------------------------------------------*/
+uint8_t APP_USB_Transmit(uint8_t* data, uint16_t size)
+{
+    // Check that USB device is connected
+    if (hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED) {
+        // Fill the USB TX buffer with the CAN data
+        return CDC_Transmit_FS(data, size);
+    }
+    return USBD_FAIL;
+}
+
 /**
   * @brief  Data to send over USB IN endpoint are sent over CDC interface
   *         through this function.


### PR DESCRIPTION
- Adds APP_USB_Transmit() to cdc interface. This
  does a check to see if the USB device is connected.

- Adds a retry limit to USB transfers from the CAN
  and GPS modules.

- Removes USBStream from the APP_ConfigType. We always
  want to stream usb data so this is useless.