### PR TITLE
Add ability to retransmit a message

### DIFF
--- a/gooey/gooey/controllers/rxtxcontroller.py
+++ b/gooey/gooey/controllers/rxtxcontroller.py
@@ -1,6 +1,7 @@
 from models.transmit_table_model import TransmitTableModel
 from models.receive_table_model import ReceiveTableModel
 from models.transmit_message import TransmitMessage
+import datetime
 
 
 class RxtxController():
@@ -15,6 +16,10 @@ class RxtxController():
         else:
             self.transmittable = TransmitTableModel()
 
+    def transmitMessage(self, message):
+        # TODO, call api to transmit message here
+        self.appendTransmitTable(message)
+
     def appendTransmitTable(self, message):
         self.transmittable.insertRow(message)
 
@@ -23,8 +28,8 @@ class RxtxController():
 
     def setTest(self):
         newmsg = TransmitMessage(
-            "Test1", "DLC", "Data", "cycle_time", "Count", "Trigger")
+            "CAN-ID1", "Message1", datetime.datetime.now().strftime("%H:%M:%S"), "FD,BRS", "DLC", 32, "Data", "cycle_time", 1, "Trigger")
         self.transmittable.messages.append(newmsg)
         newmsg2 = TransmitMessage(
-            "Test2", "DLC", "Data", "cycle_time", "Count", "Trigger")
+            "CAN-ID2", "Message2", datetime.datetime.now().strftime("%H:%M:%S"), "FD,BRS", "DLC", 32, "Data", "cycle_time", 1, "Trigger")
         self.transmittable.messages.append(newmsg2)

--- a/gooey/gooey/controllers/rxtxcontroller.py
+++ b/gooey/gooey/controllers/rxtxcontroller.py
@@ -16,12 +16,10 @@ class RxtxController():
             self.transmittable = TransmitTableModel()
 
     def appendTransmitTable(self, message):
-        num_msgs = self.transmittable.rowCount()
-        self.transmittable.insertRow(message, num_msgs)
+        self.transmittable.insertRow(message)
 
     def appendReceiveTable(self, message):
-        num_msgs = self.receivetable.rowCount()
-        self.receivetable.insertRow(message, num_msgs)
+        self.receivetable.insertRow(message)
 
     def setTest(self):
         newmsg = TransmitMessage(

--- a/gooey/gooey/controllers/tracecontroller.py
+++ b/gooey/gooey/controllers/tracecontroller.py
@@ -10,10 +10,10 @@ class TraceController():
             self.tracetable = TraceTableModel()
 
     def setTest(self):
-        newmsg = Trace(
-            "30018", "18F00200h", "Rx", "FD,BRS", "32", "00 00 C4 FB 0F FE 0F FE 00 00 C4 FB 0F FE 0F FE 00 00 C4 FB")
+        newmsg = Trace("18F00200h", "MSG",
+                       "30018", "Rx", "FD,BRS", "DLC", "32", "00 00 C4 FB 0F FE 0F FE 00 00 C4 FB 0F FE 0F FE 00 00 C4 FB", None)
         self.tracetable.traces.append(newmsg)
 
-        newmsg2 = Trace(
-            "30111", "17F00100h", "Tx", "FD", "8", "00 00 C4 FB")
+        newmsg2 = Trace("17F00100h", "MSG",
+                        "30111", "TX", "FD", "DLC", "8", "00 00 C4 FB", None)
         self.tracetable.traces.append(newmsg2)

--- a/gooey/gooey/models/message.py
+++ b/gooey/gooey/models/message.py
@@ -1,7 +1,0 @@
-class Message():
-    def __init__(self, message=None, dlc=None, data=None, cycle_time=None, count=None):
-        self.message = message
-        self.dlc = dlc
-        self.data = data
-        self.cycle_time = cycle_time
-        self.count = count

--- a/gooey/gooey/models/receive_message.py
+++ b/gooey/gooey/models/receive_message.py
@@ -1,6 +1,7 @@
-from models.message import Message
+from models.rxtxmessage import RxTxMessage
 
 
-class ReceiveMessage(Message):
-    def __init__(self, message=None, dlc=None, data=None, cycle_time=None, count=None):
-        super().__init__(message, dlc, data, cycle_time, count)
+class ReceiveMessage(RxTxMessage):
+    def __init__(self, can_id=None, message=None, time=None, msgtype=None, dlc=None, length=None, data=None, cycle_time=None, count=None):
+        super().__init__(can_id, message, time, "RX",
+                         msgtype, dlc, length, data, cycle_time, count)

--- a/gooey/gooey/models/receive_table_model.py
+++ b/gooey/gooey/models/receive_table_model.py
@@ -75,11 +75,28 @@ class ReceiveTableModel(QAbstractTableModel):
 
     """ Insert a row into the model. """
 
-    def insertRow(self, message, position, index=QModelIndex()):
-        self.beginInsertRows(QModelIndex(), position, position)
-        self.messages.insert(position, message)
-        self.endInsertRows()
+    def insertRow(self, newMessage, index=QModelIndex()):
+        # Check if Table already has a message with the same name
+        messageInTable = [
+            m for m in self.messages if m.message == newMessage.message]
+
+        if len(messageInTable) > 0:
+            self.updateMessage(messageInTable[0], newMessage)
+            self.dataChanged.emit(index, index)
+        else:
+            position = len(self.messages)
+            self.beginInsertRows(QModelIndex(), position, position)
+            self.messages.insert(position, newMessage)
+            self.endInsertRows()
+
         return True
+
+    def updateMessage(self, oldMessage, newMessage):
+        oldMessage.message = newMessage.message
+        oldMessage.dlc = newMessage.dlc
+        oldMessage.data = newMessage.data
+        oldMessage.cycle_time = newMessage.cycle_time
+        oldMessage.count = newMessage.count
 
     """ Remove a row from the model. """
 

--- a/gooey/gooey/models/receive_table_model.py
+++ b/gooey/gooey/models/receive_table_model.py
@@ -20,7 +20,7 @@ class ReceiveTableModel(QAbstractTableModel):
 
     def columnCount(self, index=QModelIndex()):
         # Documentation seem to always return a hard coded value. Probably in case self.messages is empty.
-        return 5
+        return 6
 
     """ Depending on the index and role given, return data.
         If not returning data, return None
@@ -34,6 +34,7 @@ class ReceiveTableModel(QAbstractTableModel):
             return None
 
         if role == Qt.DisplayRole:
+            can_id = self.messages[index.row()].can_id
             message = self.messages[index.row()].message
             dlc = self.messages[index.row()].dlc
             data = self.messages[index.row()].data
@@ -41,14 +42,16 @@ class ReceiveTableModel(QAbstractTableModel):
             count = self.messages[index.row()].count
 
             if index.column() == 0:
-                return message
+                return can_id
             elif index.column() == 1:
-                return dlc
+                return message
             elif index.column() == 2:
-                return data
+                return dlc
             elif index.column() == 3:
-                return cycle_time
+                return data
             elif index.column() == 4:
+                return cycle_time
+            elif index.column() == 5:
                 return count
 
         return None
@@ -61,14 +64,16 @@ class ReceiveTableModel(QAbstractTableModel):
 
         if orientation == Qt.Horizontal:
             if section == 0:
-                return "Message"
+                return "CAN ID"
             elif section == 1:
-                return "DLC"
+                return "Message"
             elif section == 2:
-                return "Data"
+                return "DLC"
             elif section == 3:
-                return "Cycle Time"
+                return "Data"
             elif section == 4:
+                return "Cycle Time"
+            elif section == 5:
                 return "Count"
 
         return None
@@ -92,6 +97,7 @@ class ReceiveTableModel(QAbstractTableModel):
         return True
 
     def updateMessage(self, oldMessage, newMessage):
+        oldMessage.can_id = newMessage.can_id
         oldMessage.message = newMessage.message
         oldMessage.dlc = newMessage.dlc
         oldMessage.data = newMessage.data
@@ -118,14 +124,16 @@ class ReceiveTableModel(QAbstractTableModel):
         if index.isValid() and 0 <= index.row() < len(self.messages):
             message = self.messages[index.row()]
             if index.column() == 0:
-                message.message = value
+                message.can_id = value
             elif index.column() == 1:
-                message.dlc = value
+                message.message = value
             elif index.column() == 2:
-                message.data = value
+                message.dlc = value
             elif index.column() == 3:
-                message.cycle_time = value
+                message.data = value
             elif index.column() == 4:
+                message.cycle_time = value
+            elif index.column() == 5:
                 message.count = value
             else:
                 False

--- a/gooey/gooey/models/rxtxmessage.py
+++ b/gooey/gooey/models/rxtxmessage.py
@@ -1,0 +1,9 @@
+from models.trace import Trace
+
+
+class RxTxMessage(Trace):
+    def __init__(self, can_id=None, message=None, time=None, rxtx=None, msgtype=None, dlc=None, length=None, data=None, cycle_time=None, count=None):
+
+        super().__init__(can_id, message, time, rxtx,
+                         msgtype, dlc, length, data, cycle_time)
+        self.count = count

--- a/gooey/gooey/models/trace.py
+++ b/gooey/gooey/models/trace.py
@@ -1,7 +1,8 @@
 class Trace():
-    def __init__(self, time=None, can_id=None, rxtx=None, msgtype=None, length=None, data=None, cycle_time=None):
-        self.time = time
+    def __init__(self, can_id=None, message=None, time=None, rxtx=None, msgtype=None, dlc=None, length=None, data=None, cycle_time=None):
         self.can_id = can_id
+        self.message = message
+        self.time = time
 
         # RX or TX
         self.rxtx = rxtx
@@ -9,6 +10,7 @@ class Trace():
         # FD or BRS?
         self.msgtype = msgtype
 
+        self.dlc = dlc
         self.length = length
         self.data = data
         self.cycle_time = cycle_time

--- a/gooey/gooey/models/transmit_message.py
+++ b/gooey/gooey/models/transmit_message.py
@@ -1,7 +1,8 @@
-from models.message import Message
+from models.rxtxmessage import RxTxMessage
 
 
-class TransmitMessage(Message):
-    def __init__(self, message=None, dlc=None, data=None, cycle_time=None, count=None, trigger=None):
-        super().__init__(message, dlc, data, cycle_time, count)
+class TransmitMessage(RxTxMessage):
+    def __init__(self, can_id=None, message=None, time=None, msgtype=None, dlc=None, length=None, data=None, cycle_time=None, count=None, trigger=None):
+        super().__init__(can_id, message, time, "TX",
+                         msgtype, dlc, length, data, cycle_time, count)
         self.trigger = trigger

--- a/gooey/gooey/models/transmit_table_model.py
+++ b/gooey/gooey/models/transmit_table_model.py
@@ -80,11 +80,29 @@ class TransmitTableModel(QAbstractTableModel):
 
     """ Insert a row into the model. """
 
-    def insertRow(self, message, position, index=QModelIndex()):
-        self.beginInsertRows(QModelIndex(), position, position)
-        self.messages.insert(position, message)
-        self.endInsertRows()
+    def insertRow(self, newMessage, index=QModelIndex()):
+        # Check if Table already has a message with the same name
+        messageInTable = [
+            m for m in self.messages if m.message == newMessage.message]
+
+        if len(messageInTable) > 0:
+            self.updateMessage(messageInTable[0], newMessage)
+            self.dataChanged.emit(index, index)
+        else:
+            position = len(self.messages)
+            self.beginInsertRows(QModelIndex(), position, position)
+            self.messages.insert(position, newMessage)
+            self.endInsertRows()
+
         return True
+
+    def updateMessage(self, oldMessage, newMessage):
+        oldMessage.message = newMessage.message
+        oldMessage.dlc = newMessage.dlc
+        oldMessage.data = newMessage.data
+        oldMessage.cycle_time = newMessage.cycle_time
+        oldMessage.count = newMessage.count
+        oldMessage.trigger = newMessage.trigger
 
     """ Remove a row from the model. """
 

--- a/gooey/gooey/models/transmit_table_model.py
+++ b/gooey/gooey/models/transmit_table_model.py
@@ -20,7 +20,7 @@ class TransmitTableModel(QAbstractTableModel):
 
     def columnCount(self, index=QModelIndex()):
         # Documentation seem to always return a hard coded value. Probably in case self.messages is empty.
-        return 6
+        return 7
 
     """ Depending on the index and role given, return data.
         If not returning data, return None
@@ -34,6 +34,7 @@ class TransmitTableModel(QAbstractTableModel):
             return None
 
         if role == Qt.DisplayRole:
+            can_id = self.messages[index.row()].can_id
             message = self.messages[index.row()].message
             dlc = self.messages[index.row()].dlc
             data = self.messages[index.row()].data
@@ -42,16 +43,18 @@ class TransmitTableModel(QAbstractTableModel):
             trigger = self.messages[index.row()].trigger
 
             if index.column() == 0:
-                return message
+                return can_id
             elif index.column() == 1:
-                return dlc
+                return message
             elif index.column() == 2:
-                return data
+                return dlc
             elif index.column() == 3:
-                return cycle_time
+                return data
             elif index.column() == 4:
-                return count
+                return cycle_time
             elif index.column() == 5:
+                return count
+            elif index.column() == 6:
                 return trigger
 
         return None
@@ -64,16 +67,18 @@ class TransmitTableModel(QAbstractTableModel):
 
         if orientation == Qt.Horizontal:
             if section == 0:
-                return "Message"
+                return "CAN ID"
             elif section == 1:
-                return "DLC"
+                return "Message"
             elif section == 2:
-                return "Data"
+                return "DLC"
             elif section == 3:
-                return "Cycle Time"
+                return "Data"
             elif section == 4:
-                return "Count"
+                return "Cycle Time"
             elif section == 5:
+                return "Count"
+            elif section == 6:
                 return "Trigger"
 
         return None
@@ -83,7 +88,7 @@ class TransmitTableModel(QAbstractTableModel):
     def insertRow(self, newMessage, index=QModelIndex()):
         # Check if Table already has a message with the same name
         messageInTable = [
-            m for m in self.messages if m.message == newMessage.message]
+            m for m in self.messages if m.can_id == newMessage.can_id]
 
         if len(messageInTable) > 0:
             self.updateMessage(messageInTable[0], newMessage)
@@ -97,11 +102,12 @@ class TransmitTableModel(QAbstractTableModel):
         return True
 
     def updateMessage(self, oldMessage, newMessage):
+        oldMessage.can_id = newMessage.can_id
         oldMessage.message = newMessage.message
         oldMessage.dlc = newMessage.dlc
         oldMessage.data = newMessage.data
         oldMessage.cycle_time = newMessage.cycle_time
-        oldMessage.count = newMessage.count
+        oldMessage.count = oldMessage.count + 1
         oldMessage.trigger = newMessage.trigger
 
     """ Remove a row from the model. """
@@ -124,16 +130,18 @@ class TransmitTableModel(QAbstractTableModel):
         if index.isValid() and 0 <= index.row() < len(self.messages):
             message = self.messages[index.row()]
             if index.column() == 0:
-                message.message = value
+                message.can_id = value
             elif index.column() == 1:
-                message.dlc = value
+                message.message = value
             elif index.column() == 2:
-                message.data = value
+                message.dlc = value
             elif index.column() == 3:
-                message.cycle_time = value
+                message.data = value
             elif index.column() == 4:
-                message.count = value
+                message.cycle_time = value
             elif index.column() == 5:
+                message.count = value
+            elif index.column() == 6:
                 message.trigger = value
             else:
                 False

--- a/gooey/gooey/ui/widgets/mainwindow.py
+++ b/gooey/gooey/ui/widgets/mainwindow.py
@@ -250,6 +250,7 @@ class CAND_MainWindow(QMainWindow):
         # TODO REMOVE THESE, ONLY FOR TEST
         self.openButton.clicked.connect(self.insertReceive)
         self.saveButton.clicked.connect(self.insertTransmit)
+        self.count = 0
 
         self.playButton.clicked.connect(self.transmitMessage)
         self.pauseButton.clicked.connect(self.retransmitMessage)
@@ -282,8 +283,9 @@ class CAND_MainWindow(QMainWindow):
 
     # TODO: REMOVE THESE, ONLY FOR TEST
     def insertTransmit(self):
+        self.count = self.count + 1
         newmsg = TransmitMessage(
-            "TestTransmit", "DLC", "Data", "cycle_time", "Count", "Trigger")
+            "TestTransmit" + str(self.count % 5), "DLC", "Data" + str(self.count), "cycle_time", "Count", "Trigger")
         self.controller.rxtxcontroller.appendTransmitTable(newmsg)
 
         test = QtWidgets.QRadioButton()
@@ -291,7 +293,6 @@ class CAND_MainWindow(QMainWindow):
         self.statusbar.addWidget(test)
 
     def insertReceive(self):
-        print("testReceive")
         newmsg = ReceiveMessage(
             "TestReceive", "DLC", "Data", "cycle_time", "Count")
         self.controller.rxtxcontroller.appendReceiveTable(newmsg)

--- a/gooey/gooey/ui/widgets/mainwindow.py
+++ b/gooey/gooey/ui/widgets/mainwindow.py
@@ -19,6 +19,7 @@ from controllers.maincontroller import MainController
 # TODO: remove below
 from models.transmit_message import TransmitMessage
 from models.receive_message import ReceiveMessage
+import datetime
 
 
 class CAND_MainWindow(QMainWindow):
@@ -262,39 +263,32 @@ class CAND_MainWindow(QMainWindow):
         transmitWindow.show()
 
         if transmitWindow.exec_():
-            # TODO: send the transmit message to hardware
-
-            print(transmitWindow.message.can_id)
-            print(transmitWindow.message.length)
-            print(transmitWindow.message.cycle_time)
-            print(transmitWindow.message.data)
-            print(transmitWindow.message.msgtype)
-            print(transmitWindow.message.rxtx)
+            self.controller.rxtxcontroller.transmitMessage(
+                transmitWindow.message)
 
     def retransmitMessage(self):
         selected = self.rxtxTab.transmitTable.selectionModel()
         if selected.hasSelection():
-            for rows in selected.selectedRows():
-                print(
-                    self.rxtxTab.controller.transmittable.messages[rows.row(
-                    )].message
-                )
-                # TODO, transmit from here
+            for row in selected.selectedRows():
+                message = self.rxtxTab.controller.transmittable.messages[row.row(
+                )]
+                self.controller.rxtxcontroller.transmitMessage(message)
 
     # TODO: REMOVE THESE, ONLY FOR TEST
     def insertTransmit(self):
         self.count = self.count + 1
         newmsg = TransmitMessage(
-            "TestTransmit" + str(self.count % 5), "DLC", "Data" + str(self.count), "cycle_time", "Count", "Trigger")
-        self.controller.rxtxcontroller.appendTransmitTable(newmsg)
+            "CAN-ID " + str(self.count % 5), "Message", datetime.datetime.now().strftime("%H:%M:%S"), "FD,BRS", "DLC", 32, "Data", "cycle_time", self.count, "Trigger")
+
+        self.controller.rxtxcontroller.transmitMessage(newmsg)
 
         test = QtWidgets.QRadioButton()
         self.statusbar.showMessage("Test Transmit | Disconnected")
         self.statusbar.addWidget(test)
 
     def insertReceive(self):
-        newmsg = ReceiveMessage(
-            "TestReceive", "DLC", "Data", "cycle_time", "Count")
+        newmsg = TransmitMessage(
+            "CAN-ID", "Message", datetime.datetime.now().strftime("%H:%M:%S"), "FD,BRS", "DLC", 32, "Data", "cycle_time", 1)
         self.controller.rxtxcontroller.appendReceiveTable(newmsg)
         self.statusbar.showMessage("Test Receive | Connected")
 
@@ -327,7 +321,6 @@ class CAND_MainWindow(QMainWindow):
 if __name__ == "__main__":
     import sys
     app = QtWidgets.QApplication(sys.argv)
-    MainWindow = QtWidgets.QMainWindow()
-    ui = CAND_MainWindow(MainWindow)
+    ui = CAND_MainWindow()
     ui.show()
     sys.exit(app.exec_())

--- a/gooey/gooey/ui/widgets/mainwindow.py
+++ b/gooey/gooey/ui/widgets/mainwindow.py
@@ -7,7 +7,7 @@
 # WARNING! All changes made in this file will be lost!
 
 import ui.widgets.resources
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets, Qt
 from PyQt5.QtWidgets import QMainWindow
 from ui.widgets.rxtx import RxTxTab
 from ui.widgets.trace import TraceTab
@@ -199,7 +199,6 @@ class CAND_MainWindow(QMainWindow):
 
         # Pause Button
         self.pauseButton = QtWidgets.QToolButton(self)
-        self.pauseButton.setEnabled(False)
         sizePolicy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
@@ -251,7 +250,9 @@ class CAND_MainWindow(QMainWindow):
         # TODO REMOVE THESE, ONLY FOR TEST
         self.openButton.clicked.connect(self.insertReceive)
         self.saveButton.clicked.connect(self.insertTransmit)
+
         self.playButton.clicked.connect(self.transmitMessage)
+        self.pauseButton.clicked.connect(self.retransmitMessage)
 
         QtCore.QMetaObject.connectSlotsByName(self)
 
@@ -268,6 +269,16 @@ class CAND_MainWindow(QMainWindow):
             print(transmitWindow.message.data)
             print(transmitWindow.message.msgtype)
             print(transmitWindow.message.rxtx)
+
+    def retransmitMessage(self):
+        selected = self.rxtxTab.transmitTable.selectionModel()
+        if selected.hasSelection():
+            for rows in selected.selectedRows():
+                print(
+                    self.rxtxTab.controller.transmittable.messages[rows.row(
+                    )].message
+                )
+                # TODO, transmit from here
 
     # TODO: REMOVE THESE, ONLY FOR TEST
     def insertTransmit(self):

--- a/gooey/gooey/ui/widgets/rxtx.py
+++ b/gooey/gooey/ui/widgets/rxtx.py
@@ -23,6 +23,7 @@ class RxTxTab(QWidget):
         self.receiveTable = QtWidgets.QTableView(self.receiveGroup)
         self.receiveTable.setEditTriggers(
             QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.receiveTable.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.receiveTable.setObjectName("receiveTable")
         self.receiveTable.setStyleSheet("font: 13pt;")
 
@@ -39,6 +40,8 @@ class RxTxTab(QWidget):
         self.transmitTable = QtWidgets.QTableView(self.transmitGroup)
         self.transmitTable.setEditTriggers(
             QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.transmitTable.setSelectionBehavior(
+            QtWidgets.QTableView.SelectRows)
         self.transmitTable.setObjectName("transmitTable")
         self.transmitTable.setStyleSheet("font: 13pt;")
 
@@ -49,8 +52,19 @@ class RxTxTab(QWidget):
         self.receiveTable.setModel(self.controller.receivetable)
         self.transmitTable.setModel(self.controller.transmittable)
 
+        self.controller.transmittable.rowsInserted.connect(
+            self.scrollTransmitToBottom)
+        self.controller.receivetable.rowsInserted.connect(
+            self.scrollReceiveToBottom)
+
         self.retranslateUi()
         QtCore.QMetaObject.connectSlotsByName(self)
+
+    def scrollTransmitToBottom(self, parent, start, end):
+        QtCore.QTimer.singleShot(0, self.transmitTable.scrollToBottom)
+
+    def scrollReceiveToBottom(self, parent, start, end):
+        QtCore.QTimer.singleShot(0, self.receiveTable.scrollToBottom)
 
     def retranslateUi(self):
         _translate = QtCore.QCoreApplication.translate

--- a/gooey/gooey/ui/widgets/trace.py
+++ b/gooey/gooey/ui/widgets/trace.py
@@ -29,9 +29,14 @@ class TraceTab(QWidget):
         header.setStretchLastSection(True)
 
         self.TraceTable.setModel(self.controller.tracetable)
+        self.controller.tracetable.rowsInserted.connect(
+            self.scrollTraceToBottom)
 
         self.retranslateUi()
         QtCore.QMetaObject.connectSlotsByName(self)
+
+    def scrollTraceToBottom(self, parent, start, end):
+        QtCore.QTimer.singleShot(0, self.TraceTable.scrollToBottom)
 
     def retranslateUi(self):
         _translate = QtCore.QCoreApplication.translate

--- a/gooey/gooey/ui/widgets/transmit.py
+++ b/gooey/gooey/ui/widgets/transmit.py
@@ -1,6 +1,6 @@
 from PyQt5 import QtCore, QtGui, QtWidgets, Qt
 from PyQt5.QtWidgets import QDialog, QPushButton
-from models.trace import Trace
+from models.transmit_message import TransmitMessage
 
 
 class TransmitWindow(QDialog):
@@ -147,7 +147,7 @@ class TransmitWindow(QDialog):
         self.buttonBox.buttons()[2].clicked.connect(self.cleared)
 
         QtCore.QMetaObject.connectSlotsByName(self)
-        self.message = Trace()
+        self.message = TransmitMessage()
 
     def retranslateUi(self):
         _translate = QtCore.QCoreApplication.translate
@@ -170,6 +170,7 @@ class TransmitWindow(QDialog):
         self.message.length = self.lengthInput.value()
         self.message.cycle_time = self.cycleInput.toPlainText()
         self.message.rxtx = "TX"
+        self.message.count = 1
 
         msgtype = []
         if (self.efCheckBox.isChecked):


### PR DESCRIPTION
Re-transmit a message by selecting a message from the Transmit table, then hit the transmit button.
Could not add a button in the table, since we are using the QTableView instead of QTableWidget (QTableView allows us to use MVC) 

Messages in receive and transmit table are unique by the CAN-ID field.

Make receive and transmit messages inherit from Trace